### PR TITLE
webpage customization support added: annotationDiv customizationHook

### DIFF
--- a/ijalLine.py
+++ b/ijalLine.py
@@ -304,6 +304,9 @@ class IjalLine:
             if translation2 != None:
                with htmlDoc.tag("div", klass="freeTranslation-tier"):
                    htmlDoc.text(translation2)
+               # add a div to hold annotations
+            with htmlDoc.tag("div", klass="annotationDiv"):
+                pass;
 
 
 # ------------------------------------------------------------------------------------------------------------------------

--- a/text.py
+++ b/text.py
@@ -178,6 +178,7 @@ class Text:
 				htmlDoc.asis('<meta charset="UTF-8"/>')
 				htmlDoc.asis(self.getJQuery())
 				htmlDoc.asis(self.getCSS())
+				htmlDoc.asis("<!-- customizationHook -->")
 			with htmlDoc.tag('body'):
 				for i in lineNumbers:
 					if(not self.quiet):


### PR DESCRIPTION
@davidjamesbeck Two small changes:

  ijalLine.py now inserts, after every translation line, an empty 

```<div class="annotationDiv"></div>```.

  text.py adds a comment line to the header 

```
  <head>
    <meta charset="UTF-8"/>
    <script src="jquery-3.3.1.min.js"></script>
    <link rel = "stylesheet" type = "text/css" href = "ijal.css" />
    <!-- customizationHook -->
  </head>
```
I replace this comment, after building a page, using the venerable unix tool ```sed```.  In my current work, this one line is replaced by these includes, which support the popup annotations:
```
<link rel="stylesheet" type="text/css" href="../pshannon.css" />
<script src="../showdown.js"></script>
<script src="../pshannon.js"></script>
<script src="../kb.js"></script>
```